### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Linked API MCP server
+
+<a href="https://glama.ai/mcp/servers/@Linked-API/linkedapi-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Linked-API/linkedapi-mcp/badge" alt="Linked API MCP server" />
+</a>
+
 Linked API MCP server connects your LinkedIn account to AI assistants like Claude, Cursor, and VS Code. Ask them to search for leads, send messages, analyze profiles, and much more – they'll handle it through our cloud browser, safely and automatically.
 
 ## Use cases


### PR DESCRIPTION
This PR adds a badge for the [Linked API MCP](https://glama.ai/mcp/servers/@Linked-API/linkedapi-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Linked-API/linkedapi-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Linked-API/linkedapi-mcp/badge" alt="Linked API MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.