### PR TITLE
Handle reverse trial exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Linked API actions run through a cloud browser and are queued like normal automa
 
 If a tool returns `status`, `workflowId`, `operationName`, and `message`, the action is still running. Do not retry the original tool because that can queue duplicate work. Call `get_workflow_result` with the exact `workflowId` and `operationName` until the final result is returned. By default `get_workflow_result` long-polls until the workflow completes or the current MCP client's request budget elapses; pass `waitSeconds: 0` for an immediate single-shot snapshot.
 
+If a tool returns `type: "trialLimitReached"` and `retryable: false`, the workspace has used its
+free trial workflow allowance. Do not retry the tool; ask the user to subscribe or contact support
+for a trial extension.
+
 ## License
 
 This project is licensed under the MIT – see the [LICENSE](https://github.com/Linked-API/linkedapi-mcp/blob/main/LICENSE) file for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@linkedapi/mcp",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@linkedapi/mcp",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
-        "@linkedapi/node": "^2.3.2",
+        "@linkedapi/node": "^2.3.3",
         "@modelcontextprotocol/sdk": "^1.17.4",
         "zod": "^4.1.1"
       },
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/@linkedapi/node": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@linkedapi/node/-/node-2.3.2.tgz",
-      "integrity": "sha512-gFm3hykS5BytgivujjGrWS54vLPsQqKNUo4meo/JXrVRcTajYus+MInbn7zaYOdEkA8YAbc7qw1hZ40s9+o0KA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@linkedapi/node/-/node-2.3.3.tgz",
+      "integrity": "sha512-a5A+ErfzHceKS5oUbFNFErSzs66qGsI0gbAmHAqL+avWTJnjiD6ErCA4FSzF3GimmRzuGQOdp9SuG8zw3Obr0w==",
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linkedapi/mcp",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "MCP server that lets AI assistants control LinkedIn accounts and retrieve real-time data.",
   "main": "dist/index.js",
   "bin": {
@@ -30,7 +30,7 @@
   "author": "Linked API",
   "license": "MIT",
   "dependencies": {
-    "@linkedapi/node": "^2.3.2",
+    "@linkedapi/node": "^2.3.3",
     "@modelcontextprotocol/sdk": "^1.17.4",
     "zod": "^4.1.1"
   },

--- a/src/utils/handle-linked-api-error.ts
+++ b/src/utils/handle-linked-api-error.ts
@@ -11,6 +11,12 @@ export function handleLinkedApiError(error: LinkedApiError): Record<string, unkn
       return {
         message: authenticationPrompt,
       };
+    case 'trialLimitReached':
+      return {
+        message: error.message,
+        type: error.type,
+        retryable: false,
+      };
   }
   return {
     message: error.message,


### PR DESCRIPTION
## Summary
- return `trialLimitReached` as a structured non-retryable MCP error
- document subscription/support remediation for agents
- update `@linkedapi/node` to 2.3.3
- bump `@linkedapi/mcp` from 2.3.1 to 2.3.2

## Impact
MCP clients stop retrying workflows after the free trial allowance is exhausted. The merge also rebuilds and redeploys the production MCP image.

## Validation
- npm run lint
- npm run build
- npm run typecheck
- npm audit: 0 vulnerabilities