### PR TITLE
Hide experimental trial error documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ Linked API actions run through a cloud browser and are queued like normal automa
 
 If a tool returns `status`, `workflowId`, `operationName`, and `message`, the action is still running. Do not retry the original tool because that can queue duplicate work. Call `get_workflow_result` with the exact `workflowId` and `operationName` until the final result is returned. By default `get_workflow_result` long-polls until the workflow completes or the current MCP client's request budget elapses; pass `waitSeconds: 0` for an immediate single-shot snapshot.
 
-If a tool returns `type: "trialLimitReached"` and `retryable: false`, the workspace has used its
-free trial workflow allowance. Do not retry the tool; ask the user to subscribe or contact support
-for a trial extension.
-
 ## License
 
 This project is licensed under the MIT – see the [LICENSE](https://github.com/Linked-API/linkedapi-mcp/blob/main/LICENSE) file for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@linkedapi/mcp",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@linkedapi/mcp",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
         "@linkedapi/node": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linkedapi/mcp",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "MCP server that lets AI assistants control LinkedIn accounts and retrieve real-time data.",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary\n- remove the experimental trial-limit error from the public README\n- keep the non-retryable runtime response unchanged\n- bump the package to 2.3.3\n\n## Validation\n- npm run lint\n- npm run build\n- npm run typecheck